### PR TITLE
feat(search): jump directly to nested schema types

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The reader accepts OpenAPI v2 definitions and OpenAPI v3 component schemas, incl
 | `/<item>/<version>/<resource>` | Schema documentation |
 | `/api/catalog` | Products and versions as JSON |
 | `/api/page?item=...&version=...&resource=...` | The same page data used by React |
+| `/api/definitions?item=kubernetes&version=1.34` | All named types and nested CRD aliases for quick search |
 | `/healthz`, `/readyz` | Ready after the corpus loads successfully |
 
 Nested inline schemas use `pointer`, a JSON Pointer through schema keywords such as `/properties/spec/properties/containers/items`; `path` carries the displayed field traversal. References are resolved by the library. Canonical schema locations make recursive references navigable without infinitely expanding the tree. Field filters remain local to the browser and are never sent to the API.
@@ -58,6 +59,12 @@ Nested inline schemas use `pointer`, a JSON Pointer through schema keywords such
 Prerendering calls the same React component used by the browser. Pages are stored compressed to bound image size. Canonical requests can use this cache; contextual URLs and errors render the same React App inside Go using [Goja](https://github.com/dop251/goja). The response already contains current headings, traversal links, circular-reference limits, and recovery controls before browser JavaScript loads. React hydrates that markup for filtering, version selection, and theme controls. Unknown resources return HTTP 404; malformed queries return HTTP 400.
 
 The build bundles the synchronous React renderer with a URLSearchParams polyfill into `frontend/dist-render/renderer.js`. Production runs two isolated Goja workers with exclusive access, a two-second rendering deadline, cancellation, and a call-stack limit. JavaScript receives page JSON and no filesystem or network bindings. See [ADR 0002](adr/0002-render-contextual-react-pages-inside-the-go-backend.md) for the runtime-rendering trade-offs and React upgrade checks.
+
+### Quick type search
+
+Use **Search all types** in the header, or press **Ctrl/Cmd+K** (also **Ctrl/Cmd+P**), to jump directly to any named type in the selected specification and version. This includes nested types such as `ContainerStatus`, not just top-level resources. Search tolerates typos and shows full type identifiers to distinguish API versions. Use arrow keys and Enter to open a result, or Escape to close the dialog and return focus.
+
+The browser loads the selected specification's definition index when search is first opened, then uses Fuse.js locally. Search text never enters URLs, API requests, logs, or telemetry. The existing `/` shortcut still focuses the current table's field filter. Search requires JavaScript; documentation and field navigation remain server-rendered.
 
 ## Verification
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@fontsource/ibm-plex-mono": "^5.2.0",
         "@grafana/faro-web-sdk": "^2.11.0",
         "@grafana/faro-web-tracing": "^2.11.0",
+        "fuse.js": "7.5.0",
         "posthog-js": "^1.427.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
@@ -2200,6 +2201,19 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.5.0.tgz",
+      "integrity": "sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/html-encoding-sniffer": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "engines": { "node": ">=24.15.0" },
+  "engines": {
+    "node": ">=24.15.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build && vite build --ssr src/entry-server.tsx --outDir dist-server && node scripts/build-renderer.mjs",
@@ -16,13 +18,12 @@
     "@fontsource/ibm-plex-mono": "^5.2.0",
     "@grafana/faro-web-sdk": "^2.11.0",
     "@grafana/faro-web-tracing": "^2.11.0",
+    "fuse.js": "7.5.0",
     "posthog-js": "^1.427.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "esbuild": "0.28.2",
-    "url-search-params-polyfill": "8.2.5",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-web": "^2.0.0",
     "@testing-library/jest-dom": "^6.9.1",
@@ -31,8 +32,10 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.1.1",
+    "esbuild": "0.28.2",
     "jsdom": "^30.0.1",
     "typescript": "^5.9.3",
+    "url-search-params-polyfill": "8.2.5",
     "vite": "^8.2.2",
     "vitest": "^5.0.0"
   }

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -77,7 +77,7 @@ describe('schema browser', () => {
 
   it('explains that unlisted definitions can still be opened directly', () => {
     render(<App initialPage={{ ...page, resource: undefined }}/>);
-    expect(screen.getByText('You can open any definition in this specification by its URL, including definitions not listed below.')).toBeVisible();
+    expect(screen.getByText('Use Search all types to jump to any definition, including nested types not listed below.')).toBeVisible();
   });
 
   it('preserves an inline selector independently from its displayed navigation path', () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { Component, useEffect, useRef, useState, type ReactNode } from 'react';
 import { specURL } from './navigation';
 import type { Link, Page, Row } from './types';
+import { QuickSearch, type SearchEvent } from './QuickSearch';
 
 const repository = 'https://github.com/TheOutdoorProgrammer/manifests.io';
 
@@ -99,7 +100,7 @@ function SchemaTable({ page }: { page: Page }) {
   </section>;
 }
 
-export function App({ initialPage: page }: { initialPage: Page }) {
+export function App({ initialPage: page, onSearchEvent }: { initialPage: Page; onSearchEvent?: (event: SearchEvent) => void }) {
   const listURL = `/${encodeURIComponent(page.item)}/${encodeURIComponent(page.version)}`;
   const issueURL = `${repository}/issues/new?${new URLSearchParams({ title: page.resource ? `${page.item} - ${page.resource}` : page.item, body: '## Description of issue\n' })}`;
   return <>
@@ -108,6 +109,7 @@ export function App({ initialPage: page }: { initialPage: Page }) {
       <div className="header-inner">
         <a className="brand" href={listURL} aria-label="Manifests.io home"><span className="brand-mark" aria-hidden="true">{'{m}'}</span><span>manifests<span className="brand-domain">.io</span></span></a>
         <span className="header-tagline">Kubernetes, documented.</span>
+        <QuickSearch key={`${page.item}/${page.version}`} item={page.item} version={page.version} onEvent={onSearchEvent}/>
         <div className="header-actions"><a className="github-link" href={repository}>GitHub <span aria-hidden="true">↗</span></a><ThemeButton/></div>
       </div>
     </header>
@@ -130,7 +132,7 @@ export function App({ initialPage: page }: { initialPage: Page }) {
         <nav className="breadcrumbs" aria-label="Breadcrumb"><ol>{(page.breadcrumbs ?? []).map((link, index, links) => <li key={`${link.href}-${index}`}><a href={link.href} aria-current={index === links.length - 1 ? 'page' : undefined}>{link.label}</a></li>)}</ol></nav>
         <div className="page-heading"><div><span className="eyebrow">{page.item} <span className="version-tag">v{page.version}</span></span><h1>{page.title || 'Documentation'}</h1></div><span className="page-symbol" aria-hidden="true">{page.resource ? '{}' : '[]'}</span></div>
         {page.description && <p className="page-description">{page.description}</p>}
-        {!page.resource && !page.error && <p className="page-description">You can open any definition in this specification by its URL, including definitions not listed below.</p>}
+        {!page.resource && !page.error && <p className="page-description">Use Search all types to jump to any definition, including nested types not listed below.</p>}
         {page.error ? <section className="error-state" role="alert"><h2>We couldn’t open this schema.</h2><p>{page.error}</p><a className="action-button" href={listURL}>Browse available resources</a></section> : <>
           <LinkList links={page.otherVersions ?? []} label="API versions" currentHref={page.canonical.split('?')[0]}/>
           <LinkList links={page.variants ?? []} label="Schema variants"/>

--- a/frontend/src/QuickSearch.test.tsx
+++ b/frontend/src/QuickSearch.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { QuickSearch, type Definition } from './QuickSearch';
+
+const definitions: Definition[] = [
+  { name: 'Container', resource: 'io.k8s.api.core.v1.Container', href: '/kubernetes/1.34/io.k8s.api.core.v1.Container' },
+  { name: 'ContainerStatus', resource: 'io.k8s.api.core.v1.ContainerStatus', href: '/kubernetes/1.34/io.k8s.api.core.v1.ContainerStatus' },
+  { name: 'Pod', resource: 'io.k8s.api.core.v1.Pod', href: '/kubernetes/1.34/io.k8s.api.core.v1.Pod' },
+];
+
+beforeEach(() => {
+  Object.defineProperty(HTMLDialogElement.prototype, 'showModal', { configurable: true, value: function (this: HTMLDialogElement) { this.open = true; } });
+  Object.defineProperty(HTMLDialogElement.prototype, 'close', { configurable: true, value: function (this: HTMLDialogElement) { this.open = false; this.dispatchEvent(new Event('close')); } });
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => definitions }));
+});
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+describe('quick type search', () => {
+  it('loads lazily, finds nested types with typos, and never transmits the search text', async () => {
+    const onEvent = vi.fn();
+    render(<QuickSearch item="kubernetes" version="1.34" onEvent={onEvent}/>);
+    expect(fetch).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Search all types' }));
+    const input = screen.getByRole('combobox', { name: 'Search all types' });
+    expect(input).toHaveFocus();
+    await screen.findByRole('option', { name: /ContainerStatus/ });
+    fireEvent.change(input, { target: { value: 'ContanerStatus' } });
+    const result = screen.getAllByRole('option')[0];
+    expect(result).toHaveTextContent('ContainerStatus');
+    expect(result).toHaveAttribute('href', definitions[1].href);
+    expect(input).toHaveAttribute('aria-activedescendant', result.id);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith('/api/definitions?item=kubernetes&version=1.34', expect.objectContaining({ signal: expect.any(AbortSignal) }));
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Search all types' }));
+    expect(input).toHaveValue('ContanerStatus');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(onEvent.mock.calls).toEqual([['search_open'], ['search_open']]);
+  });
+
+  it('supports shortcuts, arrow selection and Enter with real direct links', async () => {
+    const onEvent = vi.fn();
+    render(<QuickSearch item="kubernetes" version="1.34" onEvent={onEvent}/>);
+    fireEvent.keyDown(document.body, { key: 'k', ctrlKey: true });
+    const input = screen.getByRole('combobox', { name: 'Search all types' });
+    await screen.findByRole('option', { name: /ContainerStatus/ });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    const result = screen.getByRole('option', { name: /ContainerStatus/ });
+    expect(result).toHaveAttribute('aria-selected', 'true');
+    result.addEventListener('click', event => event.preventDefault());
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onEvent).toHaveBeenLastCalledWith('search_select');
+    fireEvent.keyDown(input, { key: 'Escape' });
+    fireEvent.keyDown(document.body, { key: 'p', metaKey: true });
+    expect(screen.getByRole('dialog')).toBeVisible();
+    expect(input).toHaveFocus();
+  });
+
+  it('recovers from failed requests and empty matches', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: false } as Response);
+    const onEvent = vi.fn();
+    render(<QuickSearch item="kubernetes" version="1.34" onEvent={onEvent}/>);
+    fireEvent.click(screen.getByRole('button', { name: 'Search all types' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry loading types' }));
+    await screen.findByRole('option', { name: /ContainerStatus/ });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Search all types' }), { target: { value: 'zzzzzzzzzzzz' } });
+    expect(screen.getByRole('status')).toHaveTextContent('No matching types');
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
+    expect(onEvent.mock.calls).toEqual([['search_open'], ['search_load_failed']]);
+  });
+
+  it('ignores completion after closing and retries on reopening', async () => {
+    let resolve!: (response: Response) => void;
+    vi.mocked(fetch).mockImplementationOnce(() => new Promise(done => { resolve = done; }));
+    render(<QuickSearch item="kubernetes" version="1.34"/>);
+    fireEvent.click(screen.getByRole('button', { name: 'Search all types' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close type search' }));
+    resolve({ ok: true, json: async () => [] } as unknown as Response);
+    await waitFor(() => expect(vi.mocked(fetch).mock.calls[0][1]?.signal?.aborted).toBe(true));
+    fireEvent.click(screen.getByRole('button', { name: 'Search all types' }));
+    await screen.findByRole('option', { name: /ContainerStatus/ });
+  });
+});

--- a/frontend/src/QuickSearch.tsx
+++ b/frontend/src/QuickSearch.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Fuse from 'fuse.js';
+
+export interface Definition {
+  name: string;
+  resource: string;
+  href: string;
+}
+
+export type SearchEvent = 'search_open' | 'search_select' | 'search_load_failed';
+
+export function QuickSearch({ item, version, onEvent }: { item: string; version: string; onEvent?: (event: SearchEvent) => void }) {
+  const dialog = useRef<HTMLDialogElement>(null);
+  const input = useRef<HTMLInputElement>(null);
+  const [enabled, setEnabled] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [definitions, setDefinitions] = useState<Definition[] | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+  const [active, setActive] = useState(0);
+  const [shortcut, setShortcut] = useState('Ctrl K');
+  const index = useMemo(() => definitions && new Fuse(definitions, {
+    keys: [{ name: 'name', weight: 3 }, 'resource'], threshold: 0.3, ignoreLocation: true,
+  }), [definitions]);
+  const matches = useMemo(() => query.trim() ? index?.search(query.trim()).map(result => result.item) ?? [] : definitions ?? [], [index, definitions, query]);
+  const visible = matches.slice(0, 50);
+
+  function show() {
+    if (dialog.current?.open) { input.current?.focus(); return; }
+    dialog.current?.showModal();
+    setOpen(true);
+    input.current?.focus();
+    onEvent?.('search_open');
+  }
+
+  useEffect(() => {
+    setEnabled(true);
+    if (/Mac|iPhone|iPad/.test(navigator.platform)) setShortcut('⌘ K');
+    function keydown(event: KeyboardEvent) {
+      if (event.defaultPrevented || event.isComposing || event.repeat || event.altKey || event.shiftKey) return;
+      if ((event.metaKey || event.ctrlKey) && ['k', 'p'].includes(event.key.toLowerCase())) {
+        event.preventDefault();
+        show();
+      }
+    }
+    document.addEventListener('keydown', keydown);
+    return () => document.removeEventListener('keydown', keydown);
+  }, [onEvent]);
+
+  useEffect(() => {
+    if (!open || definitions) return;
+    const controller = new AbortController();
+    setFailed(false);
+    void (async () => {
+      try {
+        const response = await fetch(`/api/definitions?${new URLSearchParams({ item, version })}`, { signal: controller.signal });
+        if (!response.ok) throw new Error('Definitions unavailable');
+        const data: Definition[] = await response.json();
+        if (!Array.isArray(data) || data.some(entry => typeof entry.name !== 'string' || typeof entry.resource !== 'string' || typeof entry.href !== 'string')) throw new Error('Invalid definitions');
+        if (!controller.signal.aborted) setDefinitions(data);
+      } catch {
+        if (!controller.signal.aborted) { setFailed(true); onEvent?.('search_load_failed'); }
+      }
+    })();
+    return () => controller.abort();
+  }, [open, definitions, item, version, attempt, onEvent]);
+
+  useEffect(() => {
+    if (open) document.getElementById(`type-result-${active}`)?.scrollIntoView?.({ block: 'nearest' });
+  }, [active, open, query]);
+
+  return <>
+    <button className="quick-search-trigger" disabled={!enabled} onClick={show} aria-haspopup="dialog" aria-keyshortcuts="Control+k Meta+k Control+p Meta+p">
+      <span aria-hidden="true">⌕</span><span>Search all types</span><kbd aria-hidden="true">{shortcut}</kbd>
+    </button>
+    <dialog ref={dialog} className="quick-search-dialog" aria-labelledby="type-search-title" onClose={() => setOpen(false)} onClick={event => { if (event.target === event.currentTarget) dialog.current?.close(); }}>
+      <div className="quick-search-content">
+        <div className="quick-search-heading"><div><h2 id="type-search-title">Jump to a type</h2><p>{item} / {version}, including nested types</p></div><button className="quick-search-close" aria-label="Close type search" onClick={() => dialog.current?.close()}>×</button></div>
+        <label className="sr-only" htmlFor="type-search">Search all types</label>
+        <input ref={input} id="type-search" type="search" role="combobox" aria-autocomplete="list" aria-expanded={open} aria-controls="type-search-results" aria-activedescendant={visible[active] ? `type-result-${active}` : undefined} aria-describedby="type-search-help" placeholder="Try ContainerStatus or PodSpec…" autoComplete="off" spellCheck={false} value={query} onChange={event => { setQuery(event.target.value); setActive(0); }} onKeyDown={event => {
+          if (event.nativeEvent.isComposing) return;
+          if (event.key === 'Escape') {
+            event.preventDefault();
+            dialog.current?.close();
+          } else if (['ArrowDown', 'ArrowUp'].includes(event.key)) {
+            event.preventDefault();
+            setActive(current => visible.length ? (current + (event.key === 'ArrowDown' ? 1 : -1) + visible.length) % visible.length : 0);
+          } else if (event.key === 'Enter' && visible[active]) {
+            event.preventDefault();
+            document.getElementById(`type-result-${active}`)?.click();
+          }
+        }}/>
+        <div className="quick-search-status" role="status" aria-live="polite">
+          {failed ? 'Could not load types.' : !definitions ? 'Loading types…' : !matches.length ? 'No matching types. Try a shorter name or check the selected specification.' : `${matches.length} types${matches.length > visible.length ? `, showing the first ${visible.length}. Keep typing to narrow results.` : ''}`}
+        </div>
+        {failed && <button className="action-button search-retry" onClick={() => setAttempt(value => value + 1)}>Retry loading types</button>}
+        <div className="quick-search-results" id="type-search-results" role="listbox" aria-label="Matching types" aria-busy={!definitions && !failed}>
+          {visible.map((definition, position) => <a key={definition.resource} id={`type-result-${position}`} role="option" aria-selected={position === active} tabIndex={-1} href={definition.href} onMouseMove={() => setActive(position)} onClick={() => onEvent?.('search_select')}>
+            <strong>{definition.name}</strong><span>{definition.resource}</span>
+          </a>)}
+        </div>
+        <p id="type-search-help" className="quick-search-help"><span><kbd>↑</kbd> <kbd>↓</kbd> choose <kbd>Enter</kbd> open <kbd>Esc</kbd> close</span><span>Search stays in your browser.</span></p>
+      </div>
+    </dialog>
+  </>;
+}

--- a/frontend/src/entry-client-error.test.tsx
+++ b/frontend/src/entry-client-error.test.tsx
@@ -7,7 +7,7 @@ vi.mock('react-dom/client', async importOriginal => {
   const actual = await importOriginal<typeof import('react-dom/client')>();
   return { ...actual, createRoot: vi.fn(actual.createRoot) };
 });
-vi.mock('./telemetry', () => ({ captureError: vi.fn(), initializeObservability: vi.fn() }));
+vi.mock('./telemetry', () => ({ captureError: vi.fn(), captureSearchEvent: vi.fn(), initializeObservability: vi.fn() }));
 
 it('recovers from invalid startup data with the route, full catalog, and issue reporting', async () => {
   const previousURL = window.location.href;

--- a/frontend/src/entry-client.test.tsx
+++ b/frontend/src/entry-client.test.tsx
@@ -9,7 +9,7 @@ vi.mock('react-dom/client', async importOriginal => {
   const actual = await importOriginal<typeof import('react-dom/client')>();
   return { ...actual, createRoot: vi.fn(actual.createRoot), hydrateRoot: vi.fn(actual.hydrateRoot) };
 });
-vi.mock('./telemetry', () => ({ captureError: vi.fn(), initializeObservability: vi.fn() }));
+vi.mock('./telemetry', () => ({ captureError: vi.fn(), captureSearchEvent: vi.fn(), initializeObservability: vi.fn() }));
 
 it('hydrates contextual server markup with the circular limit already rendered', async () => {
   const page: Page = {

--- a/frontend/src/entry-client.tsx
+++ b/frontend/src/entry-client.tsx
@@ -2,7 +2,7 @@ import { createRoot, hydrateRoot } from 'react-dom/client';
 import { App, AppBoundary, RecoveryPage } from './App';
 import { pageQuery } from './navigation';
 import type { Page } from './types';
-import { captureError, initializeObservability } from './telemetry';
+import { captureError, captureSearchEvent, initializeObservability } from './telemetry';
 import './styles.css';
 
 async function start() {
@@ -19,7 +19,7 @@ async function start() {
       page = await response.json() as Page;
     }
     if (!page) throw new Error('The documentation response was empty.');
-    const app = <AppBoundary page={page} onError={captureError}><App initialPage={page}/></AppBoundary>;
+    const app = <AppBoundary page={page} onError={captureError}><App initialPage={page} onSearchEvent={captureSearchEvent}/></AppBoundary>;
     if (data?.trim() && container.hasChildNodes()) hydrateRoot(container, app);
     else createRoot(container).render(app);
     try { initializeObservability(); } catch (error) { captureError(error); }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -57,6 +57,28 @@ code, kbd { font-family: var(--mono); }
 .github-link { color: var(--muted); font-size: 13px; text-decoration: none; white-space: nowrap; }
 .theme-button { border: 1px solid var(--line); background: var(--surface); border-radius: 6px; width: 40px; height: 40px; font-size: 24px; line-height: 1; }
 .theme-button:hover { background: var(--subtle); }
+.quick-search-trigger { display: flex; align-items: center; gap: 10px; margin-left: auto; min-height: 44px; min-width: 230px; padding: 8px 12px; border: 1px solid var(--line); border-radius: 6px; background: var(--bg); color: var(--muted); text-align: left; font-size: 13px; }
+.quick-search-trigger:hover { border-color: var(--accent); background: var(--accent-bg); color: var(--accent); }
+.quick-search-trigger > :first-child { font-size: 24px; line-height: 1; color: var(--accent); }
+.quick-search-trigger kbd { margin-left: auto; white-space: nowrap; }
+.quick-search-trigger ~ .header-actions { margin-left: 0; }
+.quick-search-dialog { width: min(660px, calc(100% - 32px)); max-height: calc(100dvh - 40px); margin: 8vh auto auto; padding: 0; border: 1px solid var(--line); border-radius: 10px; background: var(--surface); color: var(--text); box-shadow: 0 20px 80px #0005; }
+.quick-search-dialog::backdrop { background: #061a22a6; }
+.quick-search-content { display: flex; flex-direction: column; max-height: min(720px, 80dvh); }
+.quick-search-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 20px 22px 14px; }
+.quick-search-heading h2 { font-size: 21px; font-weight: 500; letter-spacing: -.5px; }
+.quick-search-heading p { color: var(--muted); font-size: 12px; }
+.quick-search-close { flex-shrink: 0; width: 44px; height: 44px; background: var(--subtle); border: 1px solid var(--line); border-radius: 5px; font-size: 25px; }
+.quick-search-close:hover { color: var(--accent); border-color: var(--accent); }
+#type-search { flex-shrink: 0; width: calc(100% - 44px); margin: 0 22px; padding: 12px; border: 1px solid var(--accent); border-radius: 5px; background: var(--bg); font-size: 16px; }
+.quick-search-status { color: var(--muted); font-size: 12px; padding: 12px 22px; }
+.quick-search-results { min-height: 0; overflow-y: auto; overscroll-behavior: contain; padding: 0 10px 10px; }
+.quick-search-results a { display: flex; flex-direction: column; gap: 3px; padding: 10px 12px; min-height: 58px; border: 1px solid transparent; border-radius: 5px; text-decoration: none; overflow-wrap: anywhere; }
+.quick-search-results a[aria-selected='true'] { background: var(--accent-bg); border-color: var(--accent); }
+.quick-search-results strong { font-family: var(--mono); font-size: 14px; font-weight: 500; }
+.quick-search-results a > span { font-size: 11px; color: var(--muted); }
+.quick-search-help { display: flex; flex-wrap: wrap; justify-content: space-between; gap: 6px 16px; flex-shrink: 0; padding: 12px 22px; border-top: 1px solid var(--line); color: var(--muted); font-size: 11px; }
+.search-retry { align-self: flex-start; margin: 0 22px 18px; }
 .workspace { max-width: 1552px; margin: auto; display: grid; grid-template-columns: 274px minmax(0, 1fr); padding: 0 48px; min-height: calc(100vh - 266px); }
 .workspace-sidebar { padding: 41px 28px 40px 0; border-right: 1px solid var(--line); }
 .sidebar-inner { position: sticky; top: 30px; }
@@ -148,7 +170,9 @@ tbody tr:hover { background: var(--bg); }
   thead th { padding-left: 16px; }
 }
 @media (max-width: 960px) {
-  .header-inner { padding: 15px 20px; }
+  .header-inner { padding: 15px 20px; flex-wrap: wrap; gap: 14px; }
+  .quick-search-trigger { order: 3; flex-basis: 100%; }
+  .quick-search-trigger ~ .header-actions { margin-left: auto; }
   .brand { font-size: 21px; gap: 10px; }
   .header-actions { gap: 16px; }
   .workspace { display: block; padding: 0 20px; }
@@ -169,6 +193,11 @@ tbody tr:hover { background: var(--bg); }
   .credits { text-align: left; }
 }
 @media (max-width: 480px) {
+  .quick-search-dialog { margin-top: 16px; width: calc(100% - 20px); }
+  .quick-search-content { max-height: calc(100dvh - 32px); }
+  .quick-search-heading { padding: 14px 14px 12px; }
+  #type-search { width: calc(100% - 28px); margin: 0 14px; }
+  .quick-search-status, .quick-search-help { padding: 12px 14px; }
   .header-inner { padding: 13px 16px; gap: 10px; }
   .header-actions { gap: 12px; }
   .github-link { font-size: 11px; }

--- a/frontend/src/telemetry.test.ts
+++ b/frontend/src/telemetry.test.ts
@@ -89,6 +89,7 @@ describe('browser telemetry', () => {
 
   it.each([
     ['/api/catalog?q=customer%40example.com#secret', '/api/catalog'],
+    ['/api/definitions?item=kubernetes&version=1.34&q=private', '/api/definitions'],
     ['/api/page?item=private&resource=customer%40example.com', '/api/page'],
     ['/kubernetes/v1.30/Pod?token=secret', '/:item/:version/:resource'],
     ['/cert-manager/v1.14?token=secret', '/:item/:version'],
@@ -127,6 +128,8 @@ describe('browser telemetry', () => {
       } })
       faro.api.pushEvent('faro.performance.resource', { name: url, httpHost: secret, duration: '32', responseStatus: '200' })
       faro.api.pushEvent('faro.navigation', { fromUrl: url, toUrl: window.location.href, duration: '18', text: secret })
+      faro.api.pushEvent('search_open', { query: secret, selectedType: secret })
+      faro.api.pushEvent('search_select', { query: secret })
       faro.api.pushEvent(secret, { 'faro.action.user.name': secret, name: secret, form: secret })
       faro.api.pushEvent('click', {}, undefined, {
         customPayloadTransformer: (payload) => ({ ...payload, action: { name: secret, parentId: secretID } }),
@@ -149,6 +152,8 @@ describe('browser telemetry', () => {
       expect(exported).not.toContain(secret)
       expect(exported).not.toContain(encodeURIComponent(secret))
       expect(exported).not.toContain(secretID)
+      expect(exported).toContain('search_open')
+      expect(exported).toContain('search_select')
       expect(exported).not.toContain('secret-fragment')
       expect(exported).not.toContain('authorization')
       expect(exported).toContain('/api/page')

--- a/frontend/src/telemetry.ts
+++ b/frontend/src/telemetry.ts
@@ -12,11 +12,13 @@ import {
 } from '@grafana/faro-web-sdk'
 import { TracingInstrumentation } from '@grafana/faro-web-tracing'
 import type { CaptureResult, PostHogConfig } from 'posthog-js'
+import type { SearchEvent } from './QuickSearch'
 
 const eventNames = new Set([
   'click', 'navigation', 'view_changed', 'session_start', 'session_resume', 'session_extend',
   'route_change', 'faro.navigation', 'faro.performance.navigation', 'faro.performance.resource',
   'faro.tracing.fetch', 'faro.tracing.xml-http-request', 'faro.user.action', 'securitypolicyviolation',
+  'search_open', 'search_select', 'search_load_failed',
 ])
 const methods = new Set(['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'])
 const urlAttributes = new Set(['url', 'http.url', 'url.full', 'http.target', 'fromUrl', 'toUrl', 'name', 'documentURL', 'blockedURL'])
@@ -48,6 +50,7 @@ export function telemetryURL(value: string): string {
     else if (parts[0] === 'api') {
       if (parts[1] === 'catalog') path = '/api/catalog'
       else if (parts[1] === 'page') path = '/api/page'
+      else if (parts[1] === 'definitions') path = '/api/definitions'
       else path = '/api/:path'
     } else if (parts[0] === 'assets') path = '/assets/:asset'
     else if (parts.length === 1 && ['healthz', 'readyz'].includes(parts[0])) path = `/${parts[0]}`
@@ -218,6 +221,10 @@ export function initializeObservability() {
 
 export function captureError(error: unknown) {
   faro?.api.pushError(error instanceof Error ? error : new Error('Browser error'))
+}
+
+export function captureSearchEvent(event: SearchEvent) {
+  faro?.api.pushEvent(event)
 }
 
 const analyticsHost = 'https://g.theoutdoorprogrammer.com'

--- a/internal/schema/catalog.go
+++ b/internal/schema/catalog.go
@@ -26,6 +26,12 @@ type Product struct {
 	Versions []string `json:"versions"`
 }
 
+type Definition struct {
+	Name     string `json:"name"`
+	Resource string `json:"resource"`
+	Href     string `json:"href"`
+}
+
 type Query struct {
 	Item     string `json:"item"`
 	Version  string `json:"version"`
@@ -204,6 +210,37 @@ func (c *Catalog) Products() []Product {
 		result[i] = Product{p.Name, slices.Clone(p.Versions)}
 	}
 	return result
+}
+
+func (c *Catalog) Definitions(q Query) ([]Definition, error) {
+	if q.Item == "" || q.Version == "" || strings.ContainsAny(q.Item+q.Version, "/\\\x00") || q.Resource != "" || q.Path != "" || q.Pointer != "" || q.Trail != "" || q.OneOf != "" || q.Key != "" {
+		return nil, ErrBadQuery
+	}
+	d := c.documents[q.Item+"/"+q.Version]
+	if d == nil {
+		return nil, ErrNotFound
+	}
+	definitions := make([]Definition, 0, len(d.schemas)+len(d.aliases))
+	for resource := range d.schemas {
+		link := q
+		link.Resource = resource
+		definitions = append(definitions, Definition{Name: shortName(resource), Resource: resource, Href: Href(link)})
+	}
+	for resource, loc := range d.aliases {
+		if d.schemas[resource] != nil {
+			continue
+		}
+		link := q
+		link.Resource, link.Pointer = loc.resource, loc.path
+		definitions = append(definitions, Definition{Name: shortName(resource), Resource: resource, Href: Href(link)})
+	}
+	slices.SortFunc(definitions, func(a, b Definition) int {
+		if order := strings.Compare(a.Name, b.Name); order != 0 {
+			return order
+		}
+		return strings.Compare(a.Resource, b.Resource)
+	})
+	return definitions, nil
 }
 
 func (c *Catalog) Routes() []Query {

--- a/internal/schema/definitions_test.go
+++ b/internal/schema/definitions_test.go
@@ -1,0 +1,103 @@
+package schema
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func TestDefinitionsIncludeNestedTypesAcrossTheCorpus(t *testing.T) {
+	c, err := corpus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, product := range c.Products() {
+		for _, version := range product.Versions {
+			q := Query{Item: product.Name, Version: version}
+			definitions, err := c.Definitions(q)
+			if err != nil {
+				t.Fatal(err)
+			}
+			doc := c.documents[product.Name+"/"+version]
+			seen := make(map[string]bool)
+			for i, definition := range definitions {
+				if seen[definition.Resource] {
+					t.Fatalf("duplicate definition %s in %v", definition.Resource, q)
+				}
+				seen[definition.Resource] = true
+				if i > 0 {
+					previous := definitions[i-1]
+					if previous.Name > definition.Name || (previous.Name == definition.Name && previous.Resource >= definition.Resource) {
+						t.Fatalf("unsorted definitions: %+v then %+v", previous, definition)
+					}
+				}
+				if _, err := c.Page(queryFromHref(t, definition.Href)); err != nil {
+					t.Fatalf("definition %s has invalid href %s: %v", definition.Resource, definition.Href, err)
+				}
+			}
+			for name := range doc.schemas {
+				if !seen[name] {
+					t.Errorf("missing schema %s in %v", name, q)
+				}
+			}
+			for name := range doc.aliases {
+				if !seen[name] {
+					t.Errorf("missing nested CRD definition %s in %v", name, q)
+				}
+			}
+			if product.Name == "kubernetes" && (!seen["io.k8s.api.core.v1.ContainerStatus"] || !seen["io.k8s.api.core.v1.Pod"]) {
+				t.Errorf("top-level and nested Kubernetes types must both be searchable in %s", version)
+			}
+		}
+	}
+}
+
+func TestDefinitionsPreserveIdentityAndEscapeURLs(t *testing.T) {
+	doc := newDocument(openapi3.Schemas{
+		"group.v1.Thing":   {Value: openapi3.NewObjectSchema()},
+		"group.v2.Thing":   {Value: openapi3.NewObjectSchema()},
+		"group.v1.Thing?#": {Value: openapi3.NewObjectSchema()},
+	})
+	c := &Catalog{documents: map[string]*document{"gateway api/1.2.0 standard": doc}}
+	definitions, err := c.Definitions(Query{Item: "gateway api", Version: "1.2.0 standard"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(definitions) != 3 || definitions[0].Name != "Thing" || definitions[1].Name != "Thing" || definitions[0].Resource == definitions[1].Resource {
+		t.Fatalf("same-named types were lost: %+v", definitions)
+	}
+	for _, definition := range definitions {
+		u, err := url.Parse(definition.Href)
+		if err != nil || u.RawQuery != "" || u.Fragment != "" || u.Host != "" || strings.Contains(definition.Href, " ") {
+			t.Fatalf("unsafe definition URL %q: %v", definition.Href, err)
+		}
+		if u.Path != "/gateway api/1.2.0 standard/"+definition.Resource {
+			t.Fatalf("definition URL changed identity: %+v", definition)
+		}
+	}
+}
+
+func TestDefinitionsRejectInvalidQueries(t *testing.T) {
+	c, err := corpus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, q := range []Query{
+		{}, {Item: "kubernetes"}, {Version: "1.34"},
+		{Item: "kubernetes/", Version: "1.34"},
+		{Item: "kubernetes", Version: "1.34", Resource: "io.k8s.api.core.v1.Pod"},
+		{Item: "kubernetes", Version: "1.34", Path: "Pod.spec"},
+	} {
+		if _, err := c.Definitions(q); !errors.Is(err, ErrBadQuery) {
+			t.Errorf("query %+v: got %v, want bad query", q, err)
+		}
+	}
+	for _, q := range []Query{{Item: "missing", Version: "1.34"}, {Item: "kubernetes", Version: "missing"}} {
+		if _, err := c.Definitions(q); !errors.Is(err, ErrNotFound) {
+			t.Errorf("query %+v: got %v, want not found", q, err)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -32,6 +32,7 @@ type Config struct {
 type Catalog interface {
 	Page(schema.Query) (schema.Page, error)
 	Products() []schema.Product
+	Definitions(schema.Query) ([]schema.Definition, error)
 }
 
 type Server struct {
@@ -102,6 +103,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.Pattern = "/api/catalog"
 		writeJSON(w, r, http.StatusOK, s.catalog.Products())
 		return
+	case "/api/definitions":
+		r.Pattern = "/api/definitions"
 	}
 	if strings.HasPrefix(r.URL.Path, "/assets/") {
 		r.Pattern = "/assets/{file}"
@@ -122,6 +125,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.failure(w, r, status, "This documentation URL is invalid.")
 		return
 	}
+	if r.URL.Path == "/api/definitions" {
+		definitions, err := s.catalog.Definitions(query)
+		if err != nil {
+			s.schemaFailure(w, r, err)
+			return
+		}
+		writeJSON(w, r, http.StatusOK, definitions)
+		return
+	}
 	if r.URL.Path == "/api/page" {
 		r.Pattern = "/api/page"
 	} else if query.Resource != "" {
@@ -131,13 +143,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	page, err := s.catalog.Page(query)
 	if err != nil {
-		status, message := http.StatusInternalServerError, "The documentation could not be loaded."
-		if errors.Is(err, schema.ErrNotFound) {
-			status, message = http.StatusNotFound, "This resource or version was not found."
-		} else if errors.Is(err, schema.ErrBadQuery) {
-			status, message = http.StatusBadRequest, "This documentation URL is invalid."
-		}
-		s.failure(w, r, status, message)
+		s.schemaFailure(w, r, err)
 		return
 	}
 	if r.URL.Path == "/api/page" {
@@ -161,7 +167,7 @@ func parseQuery(r *http.Request) (schema.Query, error) {
 	if q.Path == "" {
 		q.Path = values.Get("linked")
 	}
-	if r.URL.Path == "/api/page" {
+	if r.URL.Path == "/api/page" || r.URL.Path == "/api/definitions" {
 		q.Item, q.Version, q.Resource = values.Get("item"), values.Get("version"), values.Get("resource")
 	} else {
 		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/"), "/")
@@ -197,6 +203,16 @@ func (s *Server) serveFile(w http.ResponseWriter, r *http.Request, root string, 
 		w.Header().Set("Cache-Control", "public, max-age=3600")
 	}
 	http.ServeFile(w, r, file)
+}
+
+func (s *Server) schemaFailure(w http.ResponseWriter, r *http.Request, err error) {
+	status, message := http.StatusInternalServerError, "The documentation could not be loaded."
+	if errors.Is(err, schema.ErrNotFound) {
+		status, message = http.StatusNotFound, "This resource or version was not found."
+	} else if errors.Is(err, schema.ErrBadQuery) {
+		status, message = http.StatusBadRequest, "This documentation URL is invalid."
+	}
+	s.failure(w, r, status, message)
 }
 
 func (s *Server) failure(w http.ResponseWriter, r *http.Request, status int, message string) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -20,6 +20,10 @@ func (fakeCatalog) Products() []schema.Product {
 	return []schema.Product{{Name: "kubernetes", Versions: []string{"1.34"}}}
 }
 
+func (fakeCatalog) Definitions(schema.Query) ([]schema.Definition, error) {
+	return []schema.Definition{}, nil
+}
+
 func (fakeCatalog) Page(q schema.Query) (schema.Page, error) {
 	if q.Item != "kubernetes" || q.Version != "1.34" || q.Resource == "missing" {
 		return schema.Page{}, schema.ErrNotFound
@@ -130,6 +134,71 @@ func TestErrorsRemainMachineReadable(t *testing.T) {
 	var page schema.Page
 	if err := json.Unmarshal(w.Body.Bytes(), &page); err != nil || page.Error == "" || len(page.Catalog) == 0 {
 		t.Fatalf("error lacks recovery context: %s", w.Body)
+	}
+}
+
+func TestDefinitionsHTTPContract(t *testing.T) {
+	catalog, err := schema.Load("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := testServer(t)
+	s.catalog = catalog
+	for _, tc := range []struct {
+		method string
+		query  string
+		status int
+	}{
+		{"GET", "item=kubernetes&version=1.34", 200},
+		{"HEAD", "item=kubernetes&version=1.34", 200},
+		{"GET", "item=missing&version=1.34", 404},
+		{"GET", "item=kubernetes&version=missing", 404},
+		{"HEAD", "item=kubernetes&version=missing", 404},
+		{"GET", "item=kubernetes", 400},
+		{"GET", "item=kubernetes&item=flux&version=1.34", 400},
+		{"GET", "item=%ZZ&version=1.34", 400},
+		{"GET", "item=kubernetes%2F1.34&version=1.34", 400},
+		{"GET", "item=kubernetes&version=1.34&resource=Pod", 400},
+		{"GET", "item=kubernetes&version=1.34&pointer=%2Fproperties%2Fspec", 400},
+		{"POST", "item=kubernetes&version=1.34", 405},
+	} {
+		t.Run(tc.method+tc.query, func(t *testing.T) {
+			r := httptest.NewRequest(tc.method, "/api/definitions?"+tc.query, nil)
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, r)
+			if w.Code != tc.status {
+				t.Fatalf("status=%d want=%d body=%s", w.Code, tc.status, w.Body)
+			}
+			if tc.status != 405 && r.Pattern != "/api/definitions" {
+				t.Fatalf("missing low-cardinality route: %q", r.Pattern)
+			}
+			if tc.method == "HEAD" {
+				if w.Body.Len() != 0 {
+					t.Fatal("HEAD returned a body")
+				}
+				return
+			}
+			if tc.status == 200 {
+				var definitions []schema.Definition
+				if err := json.Unmarshal(w.Body.Bytes(), &definitions); err != nil {
+					t.Fatal(err)
+				}
+				found := false
+				for _, definition := range definitions {
+					if definition.Resource == "io.k8s.api.core.v1.ContainerStatus" {
+						found = definition.Name == "ContainerStatus" && definition.Href == "/kubernetes/1.34/io.k8s.api.core.v1.ContainerStatus"
+					}
+				}
+				if !found {
+					t.Fatal("nested ContainerStatus definition missing from endpoint")
+				}
+			} else if tc.status != 405 {
+				var page schema.Page
+				if err := json.Unmarshal(w.Body.Bytes(), &page); err != nil || page.Error == "" || len(page.Catalog) == 0 {
+					t.Fatalf("error lacks recovery context: %s", w.Body)
+				}
+			}
+		})
 	}
 }
 

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -16,6 +16,17 @@ const products = await (await fetch(`${base}/api/catalog`)).json();
 assert(products.some(product => product.name === 'kubernetes' && product.versions.includes('1.34')));
 assert(products.some(product => product.name === 'gateway api'));
 
+for (const [item, version, name, title] of [['kubernetes', '1.34', 'ContainerStatus', 'ContainerStatus'], ['certmanager', '1.14', 'CertificateSpec', 'Certificate.spec']]) {
+  const response = await fetch(`${base}/api/definitions?${new URLSearchParams({ item, version })}`);
+  assert.equal(response.status, 200);
+  const definitions = await response.json();
+  const match = definitions.find(definition => definition.name === name);
+  assert(match, `Quick search cannot find nested type ${name}`);
+  const document = await fetch(new URL(match.href, base));
+  assert.equal(document.status, 200);
+  assert((await document.text()).includes(`<h1>${title}</h1>`), `Search result opened the wrong type for ${name}`);
+}
+
 const pod = '/kubernetes/1.34/io.k8s.api.core.v1.Pod';
 const podSpec = '/kubernetes/1.34/io.k8s.api.core.v1.PodSpec';
 const deployment = '/kubernetes/1.34/io.k8s.api.apps.v1.Deployment';
@@ -51,6 +62,7 @@ for (const path of [pod, `${podSpec}?path=Deployment.spec.template.spec`, `${pod
   assert(body.includes('id="__PAGE_DATA__"'), `No browser data at ${path}`);
   assert(!body.includes('<!--page-'), `Incomplete template at ${path}`);
   assert(!body.includes('baadaa'), 'Old design credit is still rendered');
+  assert(body.includes('Search all types'), 'Quick search entry point is missing');
   if (path === pod) assert(body.includes(`href="${podSpec}?path=Pod.spec"`), 'Rendered spec link lost target or traversal');
   if (path.includes('path=Deployment.spec.template.spec')) assert(body.includes('<title>Deployment.spec.template.spec | Manifests.io</title>'));
   assert.equal(response.headers.get('x-content-type-options'), 'nosniff');
@@ -123,4 +135,4 @@ for (const property of ['og:site_name', 'og:image:alt', 'og:image:width', 'og:im
 }
 const missing = await (await fetch(`${base}/kubernetes/1.34/missing`)).text();
 assert(missing.includes('Specification &amp; version') && missing.includes('See an issue here?'), 'Server error lost recovery controls');
-console.log('Container smoke checks passed: API, descriptions, traversal URLs, circular limits, no resource redirects, nested SSR, required fields, errors, and headers.');
+console.log('Container smoke checks passed: API, quick search, descriptions, traversal URLs, circular limits, no resource redirects, nested SSR, required fields, errors, and headers.');


### PR DESCRIPTION
closes: https://github.com/TheOutdoorProgrammer/manifests.io/issues/94

Add a header search that jumps directly to any named type in the selected specification and version, including nested types such as ContainerStatus and CRD definitions. Open it with Ctrl/Cmd+K or Ctrl/Cmd+P, then use arrow keys and Enter to navigate. The existing `/` shortcut still filters the current field table.

The Go backend exposes the existing schema and CRD alias indexes through `/api/definitions`. Fuse.js handles fuzzy matching locally; search text never goes into requests or telemetry. The dialog supports loading failures, retry, focus trapping, and mobile layouts.

Validation: Go race tests and vet, 32 frontend tests, TypeScript and production builds, container smoke coverage, and browser checks across 19 viewport widths. Keyboard navigation, CRD links, retry, and dark/light dialog accessibility passed.
