### PR TITLE
fix(telemetry): retain public bundle identity in error stacks

### DIFF
--- a/frontend/src/telemetry.test.ts
+++ b/frontend/src/telemetry.test.ts
@@ -3,7 +3,7 @@ import { BaseTransport, initializeFaro, type TransportItem, TransportItemType } 
 import { FaroTraceExporter, TracingInstrumentation } from '@grafana/faro-web-tracing'
 import { WebTracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-web'
 import { SpanKind, SpanStatusCode } from '@opentelemetry/api'
-import { analyticsConfig, initializeAnalytics, initializeObservability, telemetryConfig, telemetryURL } from './telemetry'
+import { analyticsConfig, initializeAnalytics, initializeObservability, telemetryConfig, telemetryScript, telemetryURL } from './telemetry'
 
 class CaptureTransport extends BaseTransport {
   name = 'test-capture'
@@ -16,6 +16,17 @@ class CaptureTransport extends BaseTransport {
 }
 
 describe('browser telemetry', () => {
+  it('retains the loaded public bundle identity without exporting arbitrary filenames or URL values', () => {
+    const script = document.createElement('script')
+    script.type = 'module'
+    script.src = '/assets/index-Public01.js'
+    document.head.append(script)
+    try {
+      expect(telemetryScript(`${script.src}?private=value#secret`)).toBe(`${window.location.origin}/assets/index-Public01.js`)
+      expect(telemetryScript('/assets/customer@example.test.js')).toBe(`${window.location.origin}/assets/:asset`)
+      expect(telemetryScript('https://external.invalid/assets/index-Public01.js')).toBe('https://external.invalid/:path')
+    } finally { script.remove() }
+  })
   it('sends one private pageview through the actual PostHog SDK transport', async () => {
     const requests: { url: string, body: string, credentials?: RequestCredentials, referrerPolicy?: ReferrerPolicy }[] = []
     const request = vi.fn(async (url: string | URL | Request, options?: RequestInit) => {

--- a/frontend/src/telemetry.ts
+++ b/frontend/src/telemetry.ts
@@ -69,6 +69,19 @@ function safeAttribute(key: string, value: unknown): string | number | undefined
   return undefined
 }
 
+export function telemetryScript(value: string): string {
+  try {
+    const url = new URL(value, window.location.origin)
+    const scripts = Array.from(document.querySelectorAll('script[type="module"][src], link[rel="modulepreload"][href]'))
+    if (url.origin === window.location.origin && url.pathname.startsWith('/assets/') &&
+      scripts.some(script => {
+        const source = new URL(script.getAttribute('src') ?? script.getAttribute('href') ?? '', window.location.origin)
+        return source.origin === url.origin && source.pathname === url.pathname
+      })) return `${url.origin}${url.pathname}`
+  } catch { /* Unknown frames retain only a route template. */ }
+  return telemetryURL(value)
+}
+
 function safeAttributes(attributes: Record<string, string> = {}): Record<string, string> {
   return Object.fromEntries(Object.entries(attributes).flatMap(([key, value]) => {
     const safe = safeAttribute(key, value)
@@ -158,7 +171,7 @@ export function sanitizeTelemetry(item: TransportItem): TransportItem | null {
         trace: payload.trace,
         fatal: payload.fatal,
         stacktrace: payload.stacktrace ? { frames: payload.stacktrace.frames.map((frame) => ({
-          filename: telemetryURL(frame.filename),
+          filename: telemetryScript(frame.filename),
           function: '(anonymous)',
           lineno: frame.lineno,
           colno: frame.colno,


### PR DESCRIPTION
Preserve the loaded public JavaScript bundle name in sanitized error stacks so the existing source maps can resolve failures for a release. Only same-origin module scripts and preloads are allowed; arbitrary filenames, query values, fragments, and exception messages remain excluded.

Validation: 13 telemetry tests and the production frontend build passed, including loaded-bundle and private-filename checks.
