### PR TITLE
fix(telemetry): restore private source map publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,17 @@ jobs:
       - name: Stop production container
         if: always() && steps.container.outcome == 'success'
         run: docker stop --timeout 10 manifests
+      - name: Extract private browser source maps
+        if: github.repository == 'TheOutdoorProgrammer/manifests.io' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        run: docker build --platform linux/amd64 --target source-maps --build-arg VERSION="${GITHUB_SHA}" --output "type=local,dest=${RUNNER_TEMP}/source-maps" .
+      - name: Upload private browser source maps
+        if: github.repository == 'TheOutdoorProgrammer/manifests.io' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        env:
+          FARO_SOURCEMAP_API_KEY: ${{ secrets.FARO_SOURCEMAP_API_KEY }}
+        run: node frontend/scripts/upload-source-maps.mjs "${RUNNER_TEMP}/source-maps"
+      - name: Remove private browser source maps
+        if: always()
+        run: rm -rf "${RUNNER_TEMP}/source-maps"
       - name: Export verified image
         if: github.repository == 'TheOutdoorProgrammer/manifests.io' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         run: docker save manifests:test -o "${RUNNER_TEMP}/manifests-image.tar"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ COPY public/ /src/public/
 ARG VERSION=dev
 ENV VITE_APP_VERSION=$VERSION
 RUN npm run build
+RUN mkdir /src/source-maps && mv dist/assets/*.js.map /src/source-maps/
+
+FROM scratch AS source-maps
+COPY --from=web /src/source-maps/ /
 
 FROM golang:1.27-bookworm AS backend
 WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ Structured stdout logs include trace/span IDs. Configure `OTEL_EXPORTER_OTLP_END
 
 Production browser telemetry uses the existing public Grafana Faro collector. The existing PostHog integration retains manual pageview events on the production domains, with automatic capture, recording, persistence, and person profiles disabled. Local previews do not send production telemetry. Search values, query strings, request bodies, cookies, authorization headers, raw URLs, and freeform exceptions are excluded from exported telemetry. General OTLP credentials never enter the browser build. See [deployment telemetry configuration](infra/README.md#telemetry-configuration) for details.
 
+Production browser source maps are uploaded privately to Grafana before CI publishes a deployable image. The full Git SHA identifies both the uploaded bundle and Faro metadata. The Docker `source-maps` target exports maps from the same frontend build; runtime images omit them, and HTTP handlers reject map requests. `FARO_SOURCEMAP_API_KEY` is a GitHub Actions secret scoped to source-map operations, available only to the main-branch upload step. An absent credential or failed upload blocks publication.
+
 ## License
 
 [MIT](LICENSE). Original authorship remains in the site footer.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,8 @@
         "react-dom": "^19.2.4"
       },
       "devDependencies": {
+        "@grafana/faro-bundlers-shared": "0.12.0",
+        "@grafana/faro-rollup-plugin": "0.12.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/sdk-trace-web": "^2.0.0",
         "@playwright/test": "1.63.0",
@@ -746,6 +748,18 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@grafana/faro-bundlers-shared": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-bundlers-shared/-/faro-bundlers-shared-0.12.0.tgz",
+      "integrity": "sha512-X/QulhlO55W4Tgw9C4RSFyTVo8Aus0ChuGHH6iuVZAB1d1UZkcy6hjBCP7esdQ8vHNphmevsdcbX5ql4pA3wng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ansis": "^4.0.0",
+        "tar": "^7.5.21",
+        "undici": "^8.5.0"
+      }
+    },
     "node_modules/@grafana/faro-core": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-2.11.0.tgz",
@@ -754,6 +768,27 @@
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/otlp-transformer": "^0.221.0"
+      }
+    },
+    "node_modules/@grafana/faro-rollup-plugin": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-rollup-plugin/-/faro-rollup-plugin-0.12.0.tgz",
+      "integrity": "sha512-8VOlM9L3ZQIyz80GmZGzkoUDi4hKe9tqvavu+kJMY+en+wZ/gQY+MQ24AFBLf9e9UDFUaoiWgzk38buCXOAV2A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grafana/faro-bundlers-shared": "^0.12.0",
+        "magic-string": "^0.30.5"
+      }
+    },
+    "node_modules/@grafana/faro-rollup-plugin/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/@grafana/faro-web-sdk": {
@@ -784,6 +819,19 @@
         "@opentelemetry/resources": "^2.0.0",
         "@opentelemetry/sdk-trace-web": "^2.0.0",
         "@opentelemetry/semantic-conventions": "^1.32.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1922,6 +1970,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/ansis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -1958,6 +2016,16 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
       }
@@ -2647,6 +2715,29 @@
         "node": ">=4"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -3032,6 +3123,23 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinybench": {
       "version": "6.1.4",
@@ -3435,6 +3543,16 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,9 +25,11 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@playwright/test": "1.63.0",
+    "@grafana/faro-bundlers-shared": "0.12.0",
+    "@grafana/faro-rollup-plugin": "0.12.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-web": "^2.0.0",
+    "@playwright/test": "1.63.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^24.0.0",

--- a/frontend/scripts/upload-source-maps.mjs
+++ b/frontend/scripts/upload-source-maps.mjs
@@ -1,0 +1,24 @@
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { uploadSourceMap } from '@grafana/faro-bundlers-shared';
+
+const directory = process.argv[2];
+const release = process.env.GITHUB_SHA;
+const apiKey = process.env.FARO_SOURCEMAP_API_KEY?.trim();
+if (!directory || !/^[a-f0-9]{40}$/.test(release ?? '') || !apiKey) {
+  throw new Error('Source-map directory, full release SHA, and upload credential are required');
+}
+const files = (await readdir(directory)).filter(file => file.endsWith('.js.map'));
+if (!files.length) throw new Error('No production browser source maps found');
+for (const filename of files) {
+  const uploaded = await uploadSourceMap({
+    sourcemapEndpoint: `https://faro-api-prod-us-east-3.grafana.net/faro/api/v1/app/848/sourcemaps/${release}`,
+    stackId: '1807923',
+    apiKey,
+    filePath: join(directory, filename),
+    filename,
+    keepSourcemaps: true,
+  });
+  if (!uploaded) throw new Error(`Source-map upload failed for ${filename}`);
+}
+console.log(`Uploaded ${files.length} private source map(s) for ${release}`);

--- a/frontend/src/telemetry.test.ts
+++ b/frontend/src/telemetry.test.ts
@@ -16,6 +16,22 @@ class CaptureTransport extends BaseTransport {
 }
 
 describe('browser telemetry', () => {
+  it('retains trusted release identity through the actual Faro transport', async () => {
+    const version = '0123456789abcdef0123456789abcdef01234567'
+    const transport = new CaptureTransport()
+    const faro = initializeFaro({
+      ...telemetryConfig('https://collector.example.test', version),
+      transports: [transport],
+      instrumentations: [],
+      isolate: true,
+    })
+    try {
+      faro.api.pushError(new Error('private error text'))
+      await vi.waitFor(() => expect(transport.items).toHaveLength(1))
+      expect(transport.items[0].meta.app).toMatchObject({ version, bundleId: version, gitHash: version })
+      expect(JSON.stringify(transport.items)).not.toContain('private error text')
+    } finally { faro.pause() }
+  })
   it('retains the loaded public bundle identity without exporting arbitrary filenames or URL values', () => {
     const script = document.createElement('script')
     script.type = 'module'

--- a/frontend/src/telemetry.ts
+++ b/frontend/src/telemetry.ts
@@ -134,7 +134,15 @@ function safeTraces(payload: TraceEvent, app: TransportItem['meta']['app']): Tra
 // Rebuild payloads so newly added SDK fields cannot bypass privacy filtering.
 export function sanitizeTelemetry(item: TransportItem): TransportItem | null {
   const meta = {
-    app: item.meta.app ? { name: item.meta.app.name, version: item.meta.app.version, environment: item.meta.app.environment } : undefined,
+    app: item.meta.app ? {
+      name: item.meta.app.name,
+      version: item.meta.app.version,
+      environment: item.meta.app.environment,
+      ...(/^[a-f0-9]{40}$/.test(item.meta.app.version ?? '') ? {
+        bundleId: item.meta.app.version,
+        gitHash: item.meta.app.version,
+      } : {}),
+    } : undefined,
     sdk: item.meta.sdk,
     session: item.meta.session ? {
       id: item.meta.session.id,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,13 +1,27 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import faroUploader from '@grafana/faro-rollup-plugin';
 
-export default defineConfig({
-  plugins: [react()],
+const release = process.env.VITE_APP_VERSION || 'development';
+
+export default defineConfig(({ isSsrBuild }) => ({
+  plugins: [react(), ...(!isSsrBuild ? [faroUploader({
+    appName: 'Manifests.io',
+    endpoint: 'https://faro-api-prod-us-east-3.grafana.net/faro/api/v1',
+    appId: '848',
+    stackId: '1807923',
+    apiKey: '',
+    bundleId: release,
+    gitHash: /^[a-f0-9]{40}$/.test(release) ? release : undefined,
+    skipUpload: true,
+    prefixPath: 'https://www.manifests.io/assets/',
+    prefixPathBasenameOnly: true,
+  })] : [])],
   publicDir: '../public',
-  build: { manifest: true, sourcemap: true },
+  build: { manifest: true, sourcemap: isSsrBuild ? false : 'hidden' },
   server: {
     proxy: { '/api': 'http://localhost:8080' },
     watch: { ignored: ['**/dist-server/**', '**/prerender*/**'] },
   },
   test: { environment: 'jsdom', setupFiles: ['./src/test-setup.ts'], include: ['src/**/*.test.{ts,tsx}'] },
-});
+}));

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -128,6 +128,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if strings.HasPrefix(r.URL.Path, "/assets/") {
 		r.Pattern = "/assets/{file}"
+		if strings.HasSuffix(r.URL.Path, ".map") {
+			http.NotFound(w, r)
+			return
+		}
 		s.serveFile(w, r, s.config.WebDir, true)
 		return
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -84,6 +84,24 @@ func TestHTTPContract(t *testing.T) {
 	}
 }
 
+func TestBrowserSourceMapsStayPrivate(t *testing.T) {
+	s := testServer(t)
+	assets := filepath.Join(s.config.WebDir, "assets")
+	if err := os.Mkdir(assets, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(assets, "index.js.map"), []byte(`{"sourcesContent":["private source"]}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, method := range []string{"GET", "HEAD"} {
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, httptest.NewRequest(method, "/assets/index.js.map", nil))
+		if w.Code != http.StatusNotFound || strings.Contains(w.Body.String(), "private source") {
+			t.Fatalf("%s exposed a browser source map: status=%d", method, w.Code)
+		}
+	}
+}
+
 func TestPageDataCannotEscapeScript(t *testing.T) {
 	w := httptest.NewRecorder()
 	testServer(t).ServeHTTP(w, httptest.NewRequest("GET", "/kubernetes/1.34", nil))


### PR DESCRIPTION
The Cloud Run rewrite exposed browser source maps through static assets and dropped the private Grafana upload. Production images now omit maps, HTTP requests for them return 404, and main must upload the matching maps to Grafana before publishing an image.

Faro payloads retain the full commit SHA as the bundle and Git identity, with existing privacy filters intact. Uploads use the existing scoped source-map credential only in the main-branch CI step.

Validated: 14 real-SDK telemetry tests, server tests including a map file present on disk, TypeScript, production frontend build, actionlint, and hidden-map/bundle metadata inspection. CI also checks the full application and production container before publication.
