### PR TITLE
fix: cache public schemas and stop billing idle Cloud Run CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Publishing uses [GitHub OIDC through Google Workload Identity Federation](https:
 
 The production Spacelift stack uses [`TheOutdoorProgrammer/configurations`, `manifests/production`](https://github.com/TheOutdoorProgrammer/configurations/tree/main/manifests/production). Its OpenTofu configuration resolves the `production` tag to an immutable digest and plans the Cloud Run update. GitHub Actions publishes images; Spacelift owns infrastructure and deployment.
 
+Successful public HTML, JSON, crawler documents, redirects, and ordinary assets advertise a seven-day shared cache lifetime. Browsers revalidate those URLs, so a Cloudflare purge exposes updated content without requiring users to clear their browser cache. Hashed assets retain a one-year immutable lifetime. Health checks and errors are not cached. The production Cloudflare proxy caches eligible reads, preserves query variants, and reports `X-Manifests-Cache: HIT`, `MISS`, or `BYPASS`. Its Spacelift deployment hook purges the zone after a successful apply. To bust the cache manually, run `python3 ../../cloudflare/workers/purge-manifests-cache.py` as a task on `manifests-production`, or use Cloudflare's zone-wide **Purge Everything** action. Publishing an image alone does not invalidate the cache.
+
 1. Merge the application change into `main` and wait for both Verify jobs to succeed. A manual run on `main` follows the same checks.
 2. Start a production run in Spacelift and review the planned container digest and infrastructure changes.
 3. Approve the plan to deploy the candidate. Publishing an image alone does not change the live service.

--- a/infra/README.md
+++ b/infra/README.md
@@ -2,7 +2,7 @@
 
 This OpenTofu root runs the Go API, React frontend, and immutable schema corpus in one public Cloud Run service. It needs an existing billed project, a published linux/amd64 container image, and an existing Secret Manager secret. It creates no database, buckets, background workers, or secret payloads.
 
-The runtime has one CPU, 1 GiB memory for the parsed schema cache, at most five instances by default, and scales to zero. CPU remains allocated while an instance exists so batched telemetry can flush after requests finish. This uses instance-based billing. Startup probes allow up to two minutes for schema loading; measure peak memory with the production corpus before lowering the allocation.
+The runtime has one CPU, 1 GiB memory for the parsed schema cache, at most five instances by default, and scales to zero. It uses request-based billing with CPU throttled between requests (`cpu_idle = true`). Startup probes allow up to two minutes for schema loading; measure peak memory with the production corpus before lowering the allocation.
 
 ## Prepare a deployment
 
@@ -44,6 +44,8 @@ Use an item and version from `/api/catalog` for the page check. Confirm the depl
 ## Telemetry configuration
 
 Go uses OTLP HTTP/protobuf for traces and logs, plus structured stdout logs. Standard `OTEL_EXPORTER_OTLP_ENDPOINT`, signal-specific endpoint variables, and `OTEL_EXPORTER_OTLP_HEADERS` configure export. With no endpoint, export is disabled. `OTEL_SDK_DISABLED=true` disables both exporters; `OTEL_TRACES_EXPORTER=none` and `OTEL_LOGS_EXPORTER=none` disable individual signals. W3C TraceContext and Baggage propagation remain configured. Logs accept static messages and bounded attributes; never interpolate request data into log messages.
+
+The HTTP middleware ends the server span and emits the completion log before flushing both batch exporters concurrently. It retains the last response byte, or the headers for a bodyless response, until those flushes finish. This keeps the request active while Cloud Run supplies CPU without buffering whole schema documents. Export adds collector latency to origin requests, bounded by a shared one-second deadline; collector failures release the response and emit a sanitized local warning. Request cancellation does not cancel the bounded export attempt. Health and readiness probes bypass telemetry so collector outages cannot fail probes. Shutdown still drains requests and flushes remaining telemetry.
 
 The production container reuses the existing constrained public Faro collector; its CSP permits that collector. Docker's `VERSION` build argument also identifies the frontend build. Development builds and production previews on localhost export nothing. For Vite development with a local test collector, `VITE_FARO_URL` may point at that collector; `VITE_TELEMETRY_DISABLED=true` disables browser telemetry in a direct Vite build. These Vite development overrides are not Docker build arguments. No OTLP credential is ever a frontend build variable. Faro payloads are reconstructed through a shared privacy filter before SDK transport, with transient session IDs and no persistent session storage.
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -60,7 +60,7 @@ resource "google_cloud_run_v2_service" "app" {
           cpu    = "1"
           memory = "1Gi"
         }
-        cpu_idle          = false
+        cpu_idle          = true
         startup_cpu_boost = true
       }
       startup_probe {
@@ -92,14 +92,6 @@ resource "google_cloud_run_v2_service" "app" {
       env {
         name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
         value = "http/protobuf"
-      }
-      env {
-        name  = "OTEL_BSP_SCHEDULE_DELAY"
-        value = "1000"
-      }
-      env {
-        name  = "OTEL_BLRP_SCHEDULE_DELAY"
-        value = "1000"
       }
       env {
         name = "OTEL_EXPORTER_OTLP_HEADERS"

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -7,7 +7,9 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/contrib/bridges/otelslog"
@@ -23,11 +25,21 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+const requestFlushTimeout = time.Second
+
+type requestExporters struct {
+	flush []func(context.Context) error
+}
+
+var exporters atomic.Pointer[requestExporters]
+
 func Setup(ctx context.Context, version string) (func(context.Context) error, error) {
 	return SetupWithWriter(ctx, version, os.Stdout)
 }
 
 func SetupWithWriter(ctx context.Context, version string, output io.Writer) (func(context.Context) error, error) {
+	exporters.Store(nil)
+	request := &requestExporters{}
 	local := slog.NewJSONHandler(output, nil)
 	slog.SetDefault(slog.New(correlatedHandler{Handler: local}))
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
@@ -47,8 +59,9 @@ func SetupWithWriter(ctx context.Context, version string, output io.Writer) (fun
 		if err != nil {
 			return nil, errors.New("initialize trace exporter")
 		}
-		provider := sdktrace.NewTracerProvider(sdktrace.WithResource(res), sdktrace.WithBatcher(privateExporter{SpanExporter: exporter}))
+		provider := sdktrace.NewTracerProvider(sdktrace.WithResource(res), sdktrace.WithBatcher(privateExporter{SpanExporter: exporter}, sdktrace.WithExportTimeout(requestFlushTimeout)))
 		otel.SetTracerProvider(provider)
+		request.flush = append(request.flush, provider.ForceFlush)
 		shutdowns = append(shutdowns, provider.Shutdown)
 	} else {
 		provider := sdktrace.NewTracerProvider(sdktrace.WithResource(res), sdktrace.WithSampler(sdktrace.NeverSample()))
@@ -61,11 +74,37 @@ func SetupWithWriter(ctx context.Context, version string, output io.Writer) (fun
 			_ = shutdown(ctx)
 			return nil, errors.New("initialize log exporter")
 		}
-		provider := sdklog.NewLoggerProvider(sdklog.WithResource(res), sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter)))
+		provider := sdklog.NewLoggerProvider(sdklog.WithResource(res), sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter, sdklog.WithExportTimeout(requestFlushTimeout))))
+		request.flush = append(request.flush, provider.ForceFlush)
 		slog.SetDefault(slog.New(correlatedHandler{Handler: slog.NewMultiHandler(local, otelslog.NewHandler("manifests.io", otelslog.WithLoggerProvider(provider)))}))
 		shutdowns = append(shutdowns, provider.Shutdown)
 	}
+	exporters.Store(request)
 	return shutdown, nil
+}
+
+func flushRequest(ctx context.Context) {
+	request := exporters.Load()
+	if request == nil || len(request.flush) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), requestFlushTimeout)
+	defer cancel()
+	finished := make(chan error, len(request.flush))
+	for _, flush := range request.flush {
+		go func() { finished <- flush(ctx) }()
+	}
+	for range request.flush {
+		select {
+		case err := <-finished:
+			if err != nil {
+				otel.Handle(err)
+			}
+		case <-ctx.Done():
+			otel.Handle(ctx.Err())
+			return
+		}
+	}
 }
 
 func enabled(signal string) bool {
@@ -112,12 +151,15 @@ func safeLogKey(key string) bool {
 
 func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/healthz" || r.URL.Path == "/readyz" {
+			next.ServeHTTP(w, r)
+			return
+		}
 		started := time.Now()
 		ctx := otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
 		ctx, span := otel.Tracer("manifests.io/http").Start(ctx, "HTTP request", trace.WithSpanKind(trace.SpanKindServer))
-		defer span.End()
 		r = r.WithContext(ctx)
-		response := &responseCapture{ResponseWriter: w}
+		response := &responseCapture{ResponseWriter: w, head: r.Method == http.MethodHead}
 		defer func() {
 			route := r.Pattern
 			if route == "" {
@@ -144,6 +186,9 @@ func Middleware(next http.Handler) http.Handler {
 				span.SetStatus(codes.Error, "")
 			}
 			slog.InfoContext(ctx, "request completed", "http.request.method", method, "http.route", route, "http.response.status_code", status, "duration_ms", time.Since(started).Milliseconds())
+			span.End()
+			flushRequest(ctx)
+			response.finish()
 		}()
 		next.ServeHTTP(response, r)
 	})
@@ -151,19 +196,30 @@ func Middleware(next http.Handler) http.Handler {
 
 type responseCapture struct {
 	http.ResponseWriter
-	status int
+	status    int
+	head      bool
+	committed bool
+	headers   http.Header
+	tail      []byte
+	length    int64
+	written   int64
 }
 
-func (w *responseCapture) Unwrap() http.ResponseWriter { return w.ResponseWriter }
-
 func (w *responseCapture) WriteHeader(status int) {
+	if status < 100 || status > 999 {
+		panic("invalid HTTP status code")
+	}
 	if status >= 100 && status < 200 {
 		w.ResponseWriter.WriteHeader(status)
 		return
 	}
 	if w.status == 0 {
 		w.status = status
-		w.ResponseWriter.WriteHeader(status)
+		w.headers = w.Header().Clone()
+		w.length = -1
+		if length, err := strconv.ParseInt(w.headers.Get("Content-Length"), 10, 64); err == nil && length >= 0 {
+			w.length = length
+		}
 	}
 }
 
@@ -171,7 +227,60 @@ func (w *responseCapture) Write(body []byte) (int, error) {
 	if w.status == 0 {
 		w.WriteHeader(http.StatusOK)
 	}
-	return w.ResponseWriter.Write(body)
+	if w.head || len(body) == 0 {
+		return len(body), nil
+	}
+	if w.status == http.StatusNoContent || w.status == http.StatusNotModified {
+		return 0, http.ErrBodyNotAllowed
+	}
+	if w.length >= 0 && w.written+int64(len(body)) > w.length {
+		return 0, http.ErrContentLength
+	}
+	if w.headers.Get("Content-Type") == "" && w.headers.Get("Content-Encoding") == "" {
+		w.headers.Set("Content-Type", http.DetectContentType(body))
+	}
+	// Withhold completion so Cloud Run supplies CPU during telemetry export.
+	if len(w.tail) > 0 {
+		w.commit()
+		if _, err := w.ResponseWriter.Write(w.tail); err != nil {
+			return 0, err
+		}
+	}
+	if len(body) > 1 {
+		w.commit()
+		n, err := w.ResponseWriter.Write(body[:len(body)-1])
+		if err != nil {
+			w.tail = nil
+			return n, err
+		}
+	}
+	w.tail = append(w.tail[:0], body[len(body)-1])
+	w.written += int64(len(body))
+	return len(body), nil
+}
+
+func (w *responseCapture) commit() {
+	if w.committed {
+		return
+	}
+	if w.status == 0 {
+		w.WriteHeader(http.StatusOK)
+	}
+	header := w.Header()
+	clear(header)
+	for key, values := range w.headers {
+		header[key] = values
+	}
+	w.ResponseWriter.WriteHeader(w.status)
+	w.committed = true
+}
+
+func (w *responseCapture) finish() {
+	w.commit()
+	if len(w.tail) > 0 {
+		_, _ = w.ResponseWriter.Write(w.tail)
+		w.tail = nil
+	}
 }
 
 type privateExporter struct{ sdktrace.SpanExporter }

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -169,12 +169,10 @@ func Middleware(next http.Handler) http.Handler {
 			if status == 0 {
 				status = http.StatusOK
 			}
-			if failure := recover(); failure != nil {
+			failure := recover()
+			if failure != nil {
 				status = http.StatusInternalServerError
 				slog.ErrorContext(ctx, "request panicked", "http.route", route)
-				if response.status == 0 {
-					http.Error(response, "Internal server error", status)
-				}
 			}
 			method := r.Method
 			if !strings.Contains("|GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS|CONNECT|TRACE|", "|"+method+"|") {
@@ -188,6 +186,10 @@ func Middleware(next http.Handler) http.Handler {
 			slog.InfoContext(ctx, "request completed", "http.request.method", method, "http.route", route, "http.response.status_code", status, "duration_ms", time.Since(started).Milliseconds())
 			span.End()
 			flushRequest(ctx)
+			if failure != nil {
+				// Abort incomplete responses without exposing panic details in server logs.
+				panic(http.ErrAbortHandler)
+			}
 			response.finish()
 		}()
 		next.ServeHTTP(response, r)

--- a/internal/observability/request_test.go
+++ b/internal/observability/request_test.go
@@ -1,0 +1,274 @@
+package observability
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	logspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+func preserveTelemetry(t *testing.T) {
+	t.Helper()
+	logger, provider, propagator, errorHandler, request := slog.Default(), otel.GetTracerProvider(), otel.GetTextMapPropagator(), otel.GetErrorHandler(), exporters.Load()
+	t.Cleanup(func() {
+		slog.SetDefault(logger)
+		otel.SetTracerProvider(provider)
+		otel.SetTextMapPropagator(propagator)
+		otel.SetErrorHandler(errorHandler)
+		exporters.Store(request)
+	})
+}
+
+func TestRequestsExportBeforeResponseCompletion(t *testing.T) {
+	for _, tc := range []struct {
+		name, method, body string
+		status             int
+		panic              bool
+	}{
+		{name: "large body", method: http.MethodGet, status: 200, body: strings.Repeat("schema", 1<<16)},
+		{name: "single byte", method: http.MethodGet, status: 200, body: "x"},
+		{name: "empty", method: http.MethodGet, status: 200},
+		{name: "head", method: http.MethodHead, status: 200},
+		{name: "not modified", method: http.MethodGet, status: 304},
+		{name: "no content", method: http.MethodGet, status: 204},
+		{name: "panic", method: http.MethodGet, status: 500, body: "Internal server error\n", panic: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			preserveTelemetry(t)
+			var traces, logs atomic.Bool
+			collector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Error(err)
+				}
+				switch r.URL.Path {
+				case "/v1/traces":
+					request := new(tracepb.ExportTraceServiceRequest)
+					if err := proto.Unmarshal(body, request); err != nil {
+						t.Error(err)
+					}
+					var root, child bool
+					for _, resource := range request.ResourceSpans {
+						for _, scope := range resource.ScopeSpans {
+							for _, span := range scope.Spans {
+								root = root || span.Name == "GET /page"
+								child = child || span.Name == "react.render"
+							}
+						}
+					}
+					if !root || !child {
+						t.Errorf("request batch missing root or child: root=%v child=%v", root, child)
+					}
+					traces.Store(root && child)
+				case "/v1/logs":
+					request := new(logspb.ExportLogsServiceRequest)
+					if err := proto.Unmarshal(body, request); err != nil {
+						t.Error(err)
+					}
+					for _, resource := range request.ResourceLogs {
+						for _, scope := range resource.ScopeLogs {
+							for _, record := range scope.LogRecords {
+								if record.Body.GetStringValue() == "request completed" && len(record.TraceId) == 16 {
+									logs.Store(true)
+								}
+							}
+						}
+					}
+				}
+				w.Header().Set("Content-Type", "application/x-protobuf")
+			}))
+			t.Cleanup(collector.Close)
+			for _, key := range []string{"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "OTEL_EXPORTER_OTLP_HEADERS", "OTEL_EXPORTER_OTLP_TRACES_HEADERS", "OTEL_EXPORTER_OTLP_LOGS_HEADERS", "OTEL_SDK_DISABLED", "OTEL_TRACES_EXPORTER", "OTEL_LOGS_EXPORTER"} {
+				t.Setenv(key, "")
+			}
+			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", collector.URL)
+			t.Setenv("OTEL_BSP_SCHEDULE_DELAY", "60000")
+			t.Setenv("OTEL_BLRP_SCHEDULE_DELAY", "60000")
+			shutdown, err := SetupWithWriter(t.Context(), "test", io.Discard)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = shutdown(context.Background()) })
+			response := &completionObserver{ResponseRecorder: httptest.NewRecorder(), length: len(tc.body), check: func() {
+				if !traces.Load() || !logs.Load() {
+					t.Error("response completed before exporting server span and completion log")
+				}
+			}}
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				r.Pattern = "GET /page"
+				_, span := otel.Tracer("test").Start(r.Context(), "react.render")
+				defer span.End()
+				if tc.panic {
+					panic("synthetic failure")
+				}
+				w.Header().Set("Content-Length", strconv.Itoa(len(tc.body)))
+				w.WriteHeader(tc.status)
+				mid := len(tc.body) / 2
+				_, _ = io.WriteString(w, tc.body[:mid])
+				_, _ = io.WriteString(w, tc.body[mid:])
+			})
+			Middleware(handler).ServeHTTP(response, httptest.NewRequest(tc.method, "/page", nil))
+			if !response.completed || response.Code != tc.status || response.Body.String() != tc.body {
+				t.Fatalf("response changed: completed=%v status=%d bytes=%d", response.completed, response.Code, response.Body.Len())
+			}
+		})
+	}
+}
+
+type completionObserver struct {
+	*httptest.ResponseRecorder
+	length    int
+	completed bool
+	check     func()
+}
+
+func (w *completionObserver) WriteHeader(status int) {
+	if w.length == 0 {
+		w.check()
+		w.completed = true
+	}
+	w.ResponseRecorder.WriteHeader(status)
+}
+
+func (w *completionObserver) Write(body []byte) (int, error) {
+	if w.Body.Len()+len(body) == w.length {
+		w.check()
+		w.completed = true
+	}
+	return w.ResponseRecorder.Write(body)
+}
+
+func TestRequestFlushConcurrentBoundedAndIndependentOfCancellation(t *testing.T) {
+	preserveTelemetry(t)
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(error) {}))
+	started := make(chan struct{}, 2)
+	var workers sync.WaitGroup
+	flush := func(ctx context.Context) error {
+		defer workers.Done()
+		if ctx.Err() != nil {
+			t.Error("client cancellation canceled telemetry export")
+		}
+		started <- struct{}{}
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	workers.Add(2)
+	exporters.Store(&requestExporters{flush: []func(context.Context) error{flush, flush}})
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	finished := make(chan struct{})
+	go func() {
+		flushRequest(ctx)
+		close(finished)
+	}()
+	for range 2 {
+		select {
+		case <-started:
+		case <-time.After(requestFlushTimeout / 2):
+			t.Fatal("signals did not flush concurrently")
+		}
+	}
+	select {
+	case <-finished:
+	case <-time.After(2 * requestFlushTimeout):
+		t.Fatal("collector outage blocked response beyond flush deadline")
+	}
+	workers.Wait()
+}
+
+func TestHealthProbesDoNotWaitForTelemetry(t *testing.T) {
+	preserveTelemetry(t)
+	exporters.Store(&requestExporters{flush: []func(context.Context) error{func(context.Context) error {
+		t.Error("probe flushed telemetry")
+		return nil
+	}}})
+	for _, path := range []string{"/healthz", "/readyz"} {
+		response := httptest.NewRecorder()
+		Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = io.WriteString(w, "ok")
+		})).ServeHTTP(response, httptest.NewRequest(http.MethodGet, path, nil))
+		if response.Code != http.StatusOK || response.Body.String() != "ok" {
+			t.Fatal("probe response changed")
+		}
+	}
+}
+
+func TestResponseCapturePreservesLengthAndHeaderSemantics(t *testing.T) {
+	underlying := httptest.NewRecorder()
+	response := &responseCapture{ResponseWriter: underlying}
+	response.Header().Set("Content-Length", "4")
+	response.Header().Set("X-Before", "original")
+	response.WriteHeader(http.StatusCreated)
+	response.Header().Set("X-Before", "changed")
+	if n, err := response.Write([]byte("oversized")); n != 0 || err != http.ErrContentLength {
+		t.Fatalf("excess body accepted: n=%d err=%v", n, err)
+	}
+	if n, err := response.Write([]byte("body")); n != 4 || err != nil {
+		t.Fatalf("valid body rejected: n=%d err=%v", n, err)
+	}
+	if underlying.Body.String() != "bod" || underlying.Code != http.StatusCreated || underlying.Header().Get("X-Before") != "original" {
+		t.Fatal("response did not retain final byte or snapshot headers")
+	}
+	if n, err := response.Write([]byte("extra")); n != 0 || err != http.ErrContentLength {
+		t.Fatalf("excess subsequent body accepted: n=%d err=%v", n, err)
+	}
+	response.finish()
+	if underlying.Body.String() != "body" {
+		t.Fatalf("response body = %q", underlying.Body.String())
+	}
+}
+
+func TestCollectorOutageReleasesResponse(t *testing.T) {
+	preserveTelemetry(t)
+	var requests atomic.Int32
+	release := make(chan struct{})
+	collector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		requests.Add(1)
+		<-release
+	}))
+	t.Cleanup(func() {
+		close(release)
+		collector.Close()
+	})
+	for _, key := range []string{"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "OTEL_EXPORTER_OTLP_HEADERS", "OTEL_EXPORTER_OTLP_TRACES_HEADERS", "OTEL_EXPORTER_OTLP_LOGS_HEADERS", "OTEL_SDK_DISABLED", "OTEL_TRACES_EXPORTER", "OTEL_LOGS_EXPORTER"} {
+		t.Setenv(key, "")
+	}
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", collector.URL)
+	shutdown, err := SetupWithWriter(t.Context(), "test", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), requestFlushTimeout)
+		defer cancel()
+		_ = shutdown(ctx)
+	})
+	response := httptest.NewRecorder()
+	started := time.Now()
+	Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "2")
+		_, _ = io.WriteString(w, "ok")
+	})).ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/page", nil))
+	if elapsed := time.Since(started); elapsed > 2*requestFlushTimeout {
+		t.Errorf("collector outage blocked response for %s", elapsed)
+	}
+	if requests.Load() != 2 {
+		t.Errorf("collector received %d signal requests, want 2", requests.Load())
+	}
+	if response.Code != http.StatusOK || response.Body.String() != "ok" {
+		t.Fatal("collector outage changed response")
+	}
+}

--- a/internal/observability/request_test.go
+++ b/internal/observability/request_test.go
@@ -35,7 +35,6 @@ func TestRequestsExportBeforeResponseCompletion(t *testing.T) {
 	for _, tc := range []struct {
 		name, method, body string
 		status             int
-		panic              bool
 	}{
 		{name: "large body", method: http.MethodGet, status: 200, body: strings.Repeat("schema", 1<<16)},
 		{name: "single byte", method: http.MethodGet, status: 200, body: "x"},
@@ -43,7 +42,6 @@ func TestRequestsExportBeforeResponseCompletion(t *testing.T) {
 		{name: "head", method: http.MethodHead, status: 200},
 		{name: "not modified", method: http.MethodGet, status: 304},
 		{name: "no content", method: http.MethodGet, status: 204},
-		{name: "panic", method: http.MethodGet, status: 500, body: "Internal server error\n", panic: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			preserveTelemetry(t)
@@ -110,9 +108,6 @@ func TestRequestsExportBeforeResponseCompletion(t *testing.T) {
 				r.Pattern = "GET /page"
 				_, span := otel.Tracer("test").Start(r.Context(), "react.render")
 				defer span.End()
-				if tc.panic {
-					panic("synthetic failure")
-				}
 				w.Header().Set("Content-Length", strconv.Itoa(len(tc.body)))
 				w.WriteHeader(tc.status)
 				mid := len(tc.body) / 2
@@ -270,5 +265,55 @@ func TestCollectorOutageReleasesResponse(t *testing.T) {
 	}
 	if response.Code != http.StatusOK || response.Body.String() != "ok" {
 		t.Fatal("collector outage changed response")
+	}
+}
+
+func TestPanicsAbortHTTPResponses(t *testing.T) {
+	preserveTelemetry(t)
+	exporters.Store(nil)
+	slog.SetDefault(slog.New(slog.NewJSONHandler(io.Discard, nil)))
+	for _, tc := range []struct {
+		name, method, body string
+		headers, length    bool
+	}{
+		{name: "before headers", method: http.MethodGet},
+		{name: "empty response headers", method: http.MethodGet, headers: true, length: true},
+		{name: "head headers", method: http.MethodHead, headers: true, length: true},
+		{name: "buffered body", method: http.MethodGet, headers: true, length: true, body: "body"},
+		{name: "streamed known length", method: http.MethodGet, headers: true, length: true, body: strings.Repeat("body", 1<<15)},
+		{name: "streamed chunked", method: http.MethodGet, headers: true, body: strings.Repeat("body", 1<<15)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Cache-Control", "public, max-age=3600")
+				if tc.length {
+					w.Header().Set("Content-Length", strconv.Itoa(len(tc.body)))
+				}
+				if tc.headers {
+					w.WriteHeader(http.StatusOK)
+				}
+				if tc.body != "" {
+					_, _ = io.WriteString(w, tc.body)
+				}
+				panic("private panic details")
+			})))
+			t.Cleanup(server.Close)
+			request, err := http.NewRequestWithContext(t.Context(), tc.method, server.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			response, err := server.Client().Do(request)
+			if err != nil {
+				return
+			}
+			defer func() { _ = response.Body.Close() }()
+			body, err := io.ReadAll(response.Body)
+			if err == nil {
+				t.Fatalf("panic produced a complete cacheable response: status=%d bytes=%d", response.StatusCode, len(body))
+			}
+			if strings.Contains(string(body), "private panic details") {
+				t.Fatal("panic details leaked in response")
+			}
+		})
 	}
 }

--- a/internal/server/cache_test.go
+++ b/internal/server/cache_test.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAssetCachePolicy(t *testing.T) {
+	s := testServer(t)
+	if err := os.Mkdir(filepath.Join(s.config.WebDir, "assets"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct{ path, policy string }{
+		{"/favicon.svg", "public, max-age=0, s-maxage=604800, must-revalidate"},
+		{"/assets/index-abcd1234.js", "public, max-age=31536000, immutable"},
+	} {
+		if err := os.WriteFile(filepath.Join(s.config.WebDir, tc.path), []byte("asset"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, tc.path, nil))
+		if w.Code != http.StatusOK || w.Header().Get("Cache-Control") != tc.policy {
+			t.Fatalf("%s: status=%d cache=%q", tc.path, w.Code, w.Header().Get("Cache-Control"))
+		}
+	}
+}
+
+func TestSharedCachePolicy(t *testing.T) {
+	s := testServer(t)
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		for _, target := range []string{
+			"/", "/kubernetes/1.34", "/kubernetes/1.34/Pod?path=Deployment.spec&trail=Pod:1",
+			"/api/catalog", "/api/page?item=kubernetes&version=1.34", "/api/definitions?item=kubernetes&version=1.34",
+			"/robots.txt", "/sitemap.xml", "/sitemap-1.xml",
+		} {
+			t.Run(method+target, func(t *testing.T) {
+				w := httptest.NewRecorder()
+				s.ServeHTTP(w, httptest.NewRequest(method, target, nil))
+				if got := w.Header().Get("Cache-Control"); got != "public, max-age=0, s-maxage=604800, must-revalidate" {
+					t.Fatalf("cache policy=%q, status=%d", got, w.Code)
+				}
+				if etag := w.Header().Get("ETag"); etag != "" {
+					r := httptest.NewRequest(method, target, nil)
+					r.Header.Set("If-None-Match", etag)
+					conditional := httptest.NewRecorder()
+					s.ServeHTTP(conditional, r)
+					if conditional.Code != http.StatusNotModified || conditional.Header().Get("Cache-Control") != w.Header().Get("Cache-Control") {
+						t.Fatal("conditional response lost shared cache policy")
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestHealthAndFailuresAreNotCached(t *testing.T) {
+	s := testServer(t)
+	for _, target := range []string{
+		"/healthz", "/readyz", "/missing", "/kubernetes/1.34/missing",
+		"/api/page?item=missing&version=1", "/api/page?item=kubernetes&item=flux&version=1.34",
+		"/assets/private.js.map", "/sitemap-missing.xml",
+	} {
+		t.Run(target, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, target, nil))
+			if got := w.Header().Get("Cache-Control"); got != "no-store" {
+				t.Fatalf("health or failure cache policy=%q, status=%d", got, w.Code)
+			}
+		})
+	}
+}

--- a/internal/server/crawlers.go
+++ b/internal/server/crawlers.go
@@ -108,7 +108,7 @@ func (s *Server) serveCrawler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", file.contentType)
-	w.Header().Set("Cache-Control", "public, max-age=0, must-revalidate")
+	cachePublic(w)
 	w.Header().Set("ETag", file.etag)
 	if r.Header.Get("If-None-Match") == file.etag {
 		w.WriteHeader(http.StatusNotModified)

--- a/internal/server/crawlers_test.go
+++ b/internal/server/crawlers_test.go
@@ -185,7 +185,7 @@ func TestCrawlerHTTPContract(t *testing.T) {
 			if w.Code != 200 {
 				t.Fatalf("%s %s: status %d", method, path, w.Code)
 			}
-			if w.Header().Get("X-Content-Type-Options") != "nosniff" || w.Header().Get("Content-Length") == "" || w.Header().Get("Cache-Control") != "public, max-age=0, must-revalidate" {
+			if w.Header().Get("X-Content-Type-Options") != "nosniff" || w.Header().Get("Content-Length") == "" || w.Header().Get("Cache-Control") != "public, max-age=0, s-maxage=604800, must-revalidate" {
 				t.Fatalf("crawler headers missing: %v", w.Header())
 			}
 			if strings.Contains(w.Body.String(), "injection.invalid") {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -82,6 +82,7 @@ func RenderFilename(canonical string) string {
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 	w.Header().Set("X-Frame-Options", "DENY")
@@ -108,6 +109,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.failure(w, r, http.StatusServiceUnavailable, "No Kubernetes documentation is available.")
 			return
 		}
+		cachePublic(w)
 		http.Redirect(w, r, schema.Href(query), http.StatusTemporaryRedirect)
 		return
 	case "/api/catalog":
@@ -224,7 +226,7 @@ func (s *Server) serveFile(w http.ResponseWriter, r *http.Request, root string, 
 	if immutable {
 		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
 	} else {
-		w.Header().Set("Cache-Control", "public, max-age=3600")
+		cachePublic(w)
 	}
 	http.ServeFile(w, r, file)
 }
@@ -296,7 +298,9 @@ func (s *Server) servePage(w http.ResponseWriter, r *http.Request, status int, p
 	}
 	body = bytes.ReplaceAll(body, []byte("<!--page-head-->"), []byte(head))
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Header().Set("Cache-Control", "public, max-age=0, must-revalidate")
+	if status == http.StatusOK {
+		cachePublic(w)
+	}
 	digest := sha256.Sum256(body)
 	etag := `"` + hex.EncodeToString(digest[:]) + `"`
 	w.Header().Set("ETag", etag)
@@ -331,9 +335,15 @@ func readRendered(filename string) ([]byte, error) {
 
 func writeJSON(w http.ResponseWriter, r *http.Request, status int, value any) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.Header().Set("Cache-Control", "public, max-age=0, must-revalidate")
+	if status == http.StatusOK && strings.HasPrefix(r.URL.Path, "/api/") {
+		cachePublic(w)
+	}
 	w.WriteHeader(status)
 	if r.Method != http.MethodHead {
 		_ = json.NewEncoder(w).Encode(value)
 	}
+}
+
+func cachePublic(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "public, max-age=0, s-maxage=604800, must-revalidate")
 }


### PR DESCRIPTION
Crawler traffic was reaching Cloud Run for public documentation, while idle instances kept billing CPU to flush telemetry.

Public pages, schema APIs, redirects, and crawler files now allow seven days in shared caches; hashed assets remain immutable. Health checks and failures stay uncached. Cloud Run uses request-based billing, with traces and logs flushed before each response completes under a one-second deadline. Panics abort incomplete responses so they cannot be cached.

Validated with the rebuilt frontend, Go race suite, frontend tests, `go vet`, and OpenTofu validation. Regression tests cover cache headers, conditional requests, OTLP export ordering, collector outages, and panics over real HTTP connections.

The matching Cloudflare Worker change and cache invalidation follow production deployment through the configurations repository.
