### PR TITLE
fix(infra): remove recurring idle probe charges

### DIFF
--- a/adr/0008-use-startup-checks-without-recurring-idle-probes.md
+++ b/adr/0008-use-startup-checks-without-recurring-idle-probes.md
@@ -1,0 +1,40 @@
+# 8. Use startup checks without recurring idle probes
+
+Date: 2026-09-11
+
+## Status
+
+Accepted.
+
+## Context and Problem Statement
+
+Manifests.io must not spend compute while idle. Cloud Run uses request-based billing and zero minimum instances, but its HTTP liveness probe runs every 30 seconds. Google allocates and bills CPU and memory when probes run. The health handler returns a static success response without testing schema rendering.
+
+## Considered Options
+
+1. Retain startup readiness and remove recurring liveness probes
+2. Keep the 30-second liveness probe
+3. Increase the liveness interval
+
+## Decision Outcome
+
+Chosen: **option 1**.
+
+Keep the HTTP startup probe on /readyz so schema loading and server initialization complete before traffic is accepted. Remove the recurring liveness probe. Keep cpu_idle=true and minimum instances zero. Process exits remain visible to Cloud Run; the HTTP server and renderer retain their existing deadlines. Idle container residence alone is free under this billing configuration. Serving cache misses, startup and shutdown remain billable.
+
+## Consequences
+
+### Good
+
+- Eliminates periodic probe compute while there are no user requests.
+- Preserves startup readiness without changing application behavior, cache policy or telemetry.
+
+### Bad
+
+- A process-wide deadlock will no longer trigger a restart through the periodic liveness check; request failures and platform lifecycle controls must reveal or recover it.
+- Removing the probe does not eliminate legitimate request charges or guarantee that steady traffic lets the service reach zero instances.
+
+### Rejected because
+
+- Keeping the 30-second probe spends compute while idle and its static response does not validate the renderer.
+- A longer interval reduces recurring charges but does not meet the zero-idle-compute requirement.

--- a/adr/README.md
+++ b/adr/README.md
@@ -9,3 +9,4 @@
 | [0005](0005-share-canonical-html-and-restore-traversal-in-the-browser.md) | Share canonical HTML and restore traversal in the browser | Cache documentation by schema identity; load visitor traversal through the existing page API. |
 | [0006](0006-restore-traversal-from-embedded-canonical-page-data.md) | Restore traversal from embedded canonical page data | Share HTML and API responses by schema identity and restore traversal locally without an API request. |
 | [0007](0007-share-concurrent-renders-of-identical-page-data.md) | Share concurrent renders of identical page data | Coalesce identical in-flight renders within each process while preserving caller deadlines and cancellation. |
+| [0008](0008-use-startup-checks-without-recurring-idle-probes.md) | Use startup checks without recurring idle probes | Retain startup readiness and request-based billing without periodic liveness charges. |

--- a/infra/README.md
+++ b/infra/README.md
@@ -2,7 +2,9 @@
 
 This OpenTofu root runs the Go API, React frontend, and immutable schema corpus in one public Cloud Run service. It needs an existing billed project, a published linux/amd64 container image, and an existing Secret Manager secret. It creates no database, buckets, background workers, or secret payloads.
 
-The runtime has one CPU, 1 GiB memory for the parsed schema cache, at most five instances by default, and scales to zero. It uses request-based billing with CPU throttled between requests (`cpu_idle = true`). Startup probes allow up to two minutes for schema loading; measure peak memory with the production corpus before lowering the allocation.
+The runtime has one CPU, 1 GiB memory for the parsed schema cache, at most five instances by default, and zero minimum instances. It uses request-based billing with CPU throttled between requests (`cpu_idle = true`). Startup probes allow up to two minutes for schema loading; measure peak memory with the production corpus before lowering the allocation.
+
+There is no recurring liveness probe: [Cloud Run bills CPU and memory while probes run](https://docs.cloud.google.com/run/docs/configuring/healthchecks#cpu-allocation), even without visitor traffic. The startup check remains, and process exits are still handled by Cloud Run. A process-wide deadlock loses the periodic restart mechanism. Existing request and renderer deadlines still bound individual operations. Under [request-based pricing](https://cloud.google.com/run/pricing), idle instances above the zero minimum are free even if Cloud Run keeps them resident; startup, shutdown and actual origin requests remain billable. Steady cache misses can prevent scaling to zero without creating continuous idle charges.
 
 ## Prepare a deployment
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -72,15 +72,6 @@ resource "google_cloud_run_v2_service" "app" {
           port = 8080
         }
       }
-      liveness_probe {
-        period_seconds    = 30
-        timeout_seconds   = 1
-        failure_threshold = 3
-        http_get {
-          path = "/healthz"
-          port = 8080
-        }
-      }
       env {
         name  = "SITE_URL"
         value = var.site_url


### PR DESCRIPTION
Remove the HTTP liveness probe that runs every 30 seconds and consumes billable CPU and memory even without visitor requests. Keep the startup readiness check, request-based billing, and zero minimum instances.

Actual requests, startup and shutdown remain billable. A process-wide deadlock loses the periodic liveness restart mechanism; ADR 0008 records that tradeoff.

OpenTofu validation and formatting, ADR validation, and configurations CI passed. Production deployment changed only the probe and preserved the existing image and warm cache. Live API readback verified the settings; an origin request returned 200 with correlated Grafana telemetry, and normal requests returned cache HIT responses. The first complete measured minute recorded five requests and three billable instance-seconds.

Deployment: https://spacelift.stout.zone/stack/manifests-production/run/01M28XG0DYCA2BJCFWB182V9EM

Configuration: https://github.com/TheOutdoorProgrammer/configurations/commit/45c1968c243186b9a8bb2cbe662046e222f5c406
